### PR TITLE
Add CLI for basic configuration options in `data_handler.py`

### DIFF
--- a/src/data_handler.py
+++ b/src/data_handler.py
@@ -1,5 +1,26 @@
 # Libraries
 import sys  # Used in ImportError, SerialException
+import argparse
+
+# Parse CLI arguments
+parser = argparse.ArgumentParser()
+
+parser.add_argument(
+    "-d",
+    "--rfcomm-device",
+    default="/dev/rfcomm0",
+    help="Choose different RFCOMM device for Bluetooth connection",
+)
+
+parser.add_argument(
+    "-b",
+    "--baud-rate",
+    type=int,
+    default=9600,
+    help="Change baud rate of connection",
+)
+
+args = parser.parse_args()
 
 try:
     import serial
@@ -8,7 +29,7 @@ except ImportError:
 
 # Init
 try:
-    bt_data = serial.Serial("/dev/rfcomm0", 9600)  # Bluetooth connection
+    bt_data = serial.Serial(args.rfcomm_device, args.baud_rate)  # Bluetooth connection
     print("Initialization Successful")
 except serial.SerialException:
     sys.exit("ERROR: Connect to HC05 via Bluetooth")


### PR DESCRIPTION
Now it is possible to specify RFCOMM device other than `/dev/rfcomm0` and
baud rate using `--rfcomm-device` and `--baud-rate` arguments (or their
shorthands).
